### PR TITLE
Major update - added direction changes and comps

### DIFF
--- a/matrix.py
+++ b/matrix.py
@@ -3,11 +3,8 @@ import random
 import picounicorn
 
 # triggers:
-TRIGGER_STOP = 0
-TRIGGER_RUN = 1
-TRIGGER_TOGGLE_A = 2
-TRIGGER_TOGGLE_B = 3
-TRIGGER_TOGGLE_C = 4
+TRIGGER_RUN, TRIGGER_1, TRIGGER_2, TRIGGER_3, TRIGGER_4 = 0, 1, 2, 3, 4
+triggers = (TRIGGER_1, TRIGGER_2, TRIGGER_3, TRIGGER_4)
 
 ACTIVE_TRIGGER = TRIGGER_RUN
 
@@ -40,8 +37,21 @@ colors = (
 # lengths in dots of starting (bright) part, following dots and dots inbetween
 compositions = (((1, 1), (4, 15), (1, 3)),  # medium long, short start
                 ((1, 3), (7, 25), (2, 4)),  # longer start and lines
+                ((1, 2), (4, 15), (0, 0)),  # no gap
                 ((1, 1), (3, 10), (1, 2)),  # shorter lines
-                ((1, 2), (4, 15), (0, 0)))  # no gap
+                ((0, 0), (4, 15), (1, 3)),  # no start
+                ((0, 0), (1, 2), (3, 10)),  # rain drops with long gap
+                ((0, 0), (1, 1), (10, 30)),  # small rain drops with very long gap
+                ((0, 0), (0, 1), (20, 50)),  # very few small rain drops with very long gap
+                ((1, 1), (0, 0), (10, 30)),  # small shiny rain drops with very long gap
+                ((0, 1), (0, 0), (20, 50)))  # very few shiny small rain drops with very long gap
+
+# directions in which the lines will scroll
+directions = (
+    lambda: lambda y: HEIGHT - 1 - y,  # downwards
+    lambda: lambda y: y,  # upwards
+    lambda: random.choice((lambda y: HEIGHT - 1 - y, lambda y: y))  # random direction
+)
 
 
 def next_index(values: (), current_index: int) -> int:
@@ -65,40 +75,44 @@ def init_picounicorn() -> None:
 
 class Matrix:
     def __init__(self):
-        self.current_color_index, self.current_delay_index, self.current_composition_index = 0, 1, 0
+        self.direction_index, self.color_index, self.delay_index, self.composition_index = 0, 0, 1, 0
         self.lines = self._create_lines()
-        self.mode_trigger_methods = {TRIGGER_TOGGLE_A: self.cycle_colors,
-                                     TRIGGER_TOGGLE_B: self.cycle_scrolling_speeds,
-                                     TRIGGER_TOGGLE_C: self.cycle_line_compositions}
+        self.trigger_methods = {TRIGGER_1: self.cycle_colors, TRIGGER_2: self.cycle_scrolling_speeds,
+                                TRIGGER_3: self.cycle_scrolling_directions, TRIGGER_4: self.cycle_line_compositions}
         self.matrix_cache = self.create_matrix_cache()
         self.start_loops()
 
     @staticmethod
     def create_matrix_cache() -> []:
-        return [[2 for y in range(HEIGHT)] for x in range(WIDTH)]
+        return [[2 for _1 in range(HEIGHT)] for _2 in range(WIDTH)]
 
     async def cycle_colors(self) -> None:
-        self.current_color_index = next_index(colors, self.current_color_index)
+        self.color_index = next_index(colors, self.color_index)
         self.update_display()
 
     async def cycle_scrolling_speeds(self) -> None:
-        self.current_delay_index = next_index(delays, self.current_delay_index)
+        self.delay_index = next_index(delays, self.delay_index)
         self.update_scrolling_speeds()
 
+    async def cycle_scrolling_directions(self) -> None:
+        self.direction_index = next_index(directions, self.direction_index)
+        self.update_scrolling_directions()
+
     async def cycle_line_compositions(self) -> None:
-        self.current_composition_index = next_index(compositions, self.current_composition_index)
+        self.composition_index = next_index(compositions, self.composition_index)
 
     def _create_lines(self) -> []:
-        return [MatrixLine(x_coord=i, comp_supplier=lambda: compositions[self.current_composition_index],
-                           delay_supplier=lambda: delays[self.current_delay_index], shift=random_range(LENGTH_PREFIX),
-                           callback_update_line=self.update_line) for
-                i in range(WIDTH)]
+        return [MatrixLine(x_coord=i, comp_supplier=lambda: compositions[self.composition_index],
+                           delay_supplier=lambda: delays[self.delay_index],
+                           direction_supplier=directions[self.direction_index](),
+                           shift=random_range(LENGTH_PREFIX),
+                           callback_update_line=self.update_line) for i in range(WIDTH)]
 
     async def handle_toggle_triggers(self) -> None:
         global ACTIVE_TRIGGER
         while True:
-            if TRIGGER_TOGGLE_A <= ACTIVE_TRIGGER <= TRIGGER_TOGGLE_C:
-                await self.mode_trigger_methods.get(ACTIVE_TRIGGER)()
+            if ACTIVE_TRIGGER in triggers:
+                await self.trigger_methods.get(ACTIVE_TRIGGER)()
                 ACTIVE_TRIGGER = TRIGGER_RUN
             await uasyncio.sleep(0)
 
@@ -107,31 +121,36 @@ class Matrix:
         for line in self.lines:
             uasyncio.create_task(line.scroll())
 
-    def update_line(self, x: int, line: [], cache=True) -> None:
+    def update_line(self, x: int, line: [], direction_supplier, cache=True) -> None:
         for y, part in enumerate(line):
-            r, g, b = colors[self.current_color_index][part]
-            picounicorn.set_pixel(x, HEIGHT - 1 - y, r, g, b)  # shifting up lines to the top of picounicorn
+            r, g, b = colors[self.color_index][part]
+            picounicorn.set_pixel(x, direction_supplier(y), r, g, b)  # shifting up lines to the top of picounicorn
         if cache:
             self.matrix_cache[x] = line
 
     def update_display(self) -> None:
         for x in range(WIDTH):
-            self.update_line(x, self.matrix_cache[x], cache=False)
+            self.update_line(x, self.matrix_cache[x], self.lines[x].direction_supplier, cache=False)
 
     def update_scrolling_speeds(self) -> None:
         for line in self.lines:
-            line.current_delay = random_range_factor(delays[self.current_delay_index])
+            line.current_delay = random_range_factor(delays[self.delay_index])
+
+    def update_scrolling_directions(self) -> None:
+        for line in self.lines:
+            line.direction_supplier = directions[self.direction_index]()
 
 
 class MatrixLine:
-    def __init__(self, x_coord: int, comp_supplier, delay_supplier, shift: int, callback_update_line) -> None:
+    def __init__(self, x_coord: int, comp_supplier, delay_supplier, direction_supplier, shift: int,
+                 callback_update_line) -> None:
         self.x_coord = x_coord
         self.delay_supplier = delay_supplier
         self.current_delay = random_range_factor(self.delay_supplier())
+        self.direction_supplier = direction_supplier
         self.comp_supplier = comp_supplier
         self.current_comp_index = 0
-        self.dots = [2 for _ in
-                     range(shift)]  # initial shifting of line start to already have some variety in the beginning
+        self.dots = [2 for _ in range(shift)]  # initial shifting of line start for some variety in the beginning
         self.callback_update_line = callback_update_line
 
     def _add_dots(self) -> None:
@@ -149,13 +168,13 @@ class MatrixLine:
             while ACTIVE_TRIGGER == TRIGGER_RUN:
                 while len(self.dots) < HEIGHT:  # lengthen line if too short for display
                     self._add_dots()
-                self.callback_update_line(self.x_coord, self.dots[0:HEIGHT])  # show visible dots
+                self.callback_update_line(self.x_coord, self.dots[0:HEIGHT], self.direction_supplier)
                 self.dots = self.dots[1:]  # remove lowest dot from line
                 await uasyncio.sleep(self.current_delay)
             await uasyncio.sleep(0)
 
 
-async def toggle_mode(trigger: int) -> None:
+async def set_trigger(trigger: int) -> None:
     global ACTIVE_TRIGGER
     ACTIVE_TRIGGER = trigger
     await uasyncio.sleep(0.3)
@@ -164,14 +183,14 @@ async def toggle_mode(trigger: int) -> None:
 async def handle_buttons() -> None:
     while True:
         if picounicorn.is_pressed(picounicorn.BUTTON_A):
-            await toggle_mode(TRIGGER_STOP) if ACTIVE_TRIGGER != TRIGGER_STOP else await toggle_mode(TRIGGER_RUN)
+            await set_trigger(TRIGGER_1)
         if picounicorn.is_pressed(picounicorn.BUTTON_B):
-            await toggle_mode(TRIGGER_TOGGLE_A)
+            await set_trigger(TRIGGER_2)
         if picounicorn.is_pressed(picounicorn.BUTTON_X):
-            await toggle_mode(TRIGGER_TOGGLE_B)
+            await set_trigger(TRIGGER_3)
         if picounicorn.is_pressed(picounicorn.BUTTON_Y):
-            await toggle_mode(TRIGGER_TOGGLE_C)
-        await uasyncio.sleep(0.1)
+            await set_trigger(TRIGGER_4)
+        await uasyncio.sleep(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added many line compositions for rain-like animations with different up to very long gaps. Used start and body part of composition for normal and shiny rain drops.

Removed pausing, but added direction change instead! Now the Matrix can flow down, up or a random combination of both. Can be done on the fly - no reset.

To be honest I didn't expect to get so many new cool looking combinations out of the composition additions :) In combination with the direction change this gives the Matrix scroller many new looks.

Renamed triggers, trigger methods and some methods. Some code cleanup.
Added new line compositions.
Added directions down, up and random.