### PR TITLE
Performance fix and readability

### DIFF
--- a/matrix.py
+++ b/matrix.py
@@ -93,7 +93,7 @@ class Matrix:
     async def cycle_line_compositions(self) -> None:
         self.composition_index = next_index(compositions, self.composition_index)
         for x, line in enumerate(self.lines):  # shortening very long lines to see comp change earlier
-            line.dots = line.dots[0: len(line.dots) - 20] if HEIGHT <= len(line.dots) >= 30 else line.dots
+            line.dots = line.dots[0: len(line.dots) - 20] if HEIGHT <= len(line.dots) >= 40 else line.dots
 
     def _create_lines(self) -> []:
         return [MatrixLine(x_coord=i, comp_supplier=lambda: compositions[self.composition_index],


### PR DESCRIPTION
Not creating a new list when updating each list display any more. Using existing line and just reading necessary indices. Had to append one more dot to line as the first one now gets removed after calling the method to display it. As this happens async, the .pop(0) occurs earlier as the loop to display the line is done. This led to an Exception because the index of the line was already deleted.

Using names for the line parts START, BODY, GAP in the code and mapping the current comp index to it. This is only for readybility issues as it was not obvious why the index is added.

Inlined matrix cache creation as it was reduced earlier to a one-liner by using a nested list comprehension.

Shortened (-20) very long lines (>40) when changing line compositions

Inlined the update methods which were only called from one location and added some documentation.